### PR TITLE
Cleanup for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "description": "Translate git logs into Release Notes / Changelog",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npx tsc",
-    "start": "npx ts-node ./src/index.ts"
+    "start": "npx ts-node ./src/index.ts",
+    "prepublish": "tsc"
   },
   "author": "Brian Sanchez <brian@rokk3r.com> (https://www.rokk3r.com)",
   "license": "MIT",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,7 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */


### PR DESCRIPTION
🔧 chore(package.json): add types field to specify index.d.ts as the types file
🔧 chore(package.json): add prepublish script to run tsc before publishing
🔧 chore(tsconfig.json): set declaration to true to generate .d.ts files